### PR TITLE
chore(argocd): bump tailscale-operator chart to 1.94.2

### DIFF
--- a/oracle-arm/argocd/tailscale-operator.yaml
+++ b/oracle-arm/argocd/tailscale-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://pkgs.tailscale.com/helmcharts
     chart: tailscale-operator
-    targetRevision: 1.78.3
+    targetRevision: 1.94.2
     helm:
       valuesObject:
         oauth:


### PR DESCRIPTION
### Motivation
- Keep the deployed Tailscale Kubernetes operator up-to-date by switching the Argo CD application to the newest published Helm chart version to receive bug fixes and improvements.
- The change targets the `tailscale-operator` chart published in the official Tailscale Helm repository.

### Description
- Updated `targetRevision` in `oracle-arm/argocd/tailscale-operator.yaml` from `1.78.3` to `1.94.2`.
- The change affects the Argo CD `Application` that sources the chart from `https://pkgs.tailscale.com/helmcharts`.
- Committed the update with the message `chore: bump tailscale operator chart to latest`.

### Testing
- Verified the latest chart version by fetching the upstream index with `curl -fsSL https://pkgs.tailscale.com/helmcharts/index.yaml` and confirming `tailscale-operator` lists `1.94.2`, which succeeded.
- Reviewed the local change with `git diff` to ensure only the intended `targetRevision` was modified, which succeeded.
- Created a commit containing the single-file change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af45d3d1b48330ae01c5fb05de1322)