### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   renovate:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,7 +9,6 @@ jobs:
   renovate:
     permissions:
       contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/belgio99/homelab/security/code-scanning/7](https://github.com/belgio99/homelab/security/code-scanning/7)

To fix the problem, explicitly set least-privilege `permissions` for the `GITHUB_TOKEN` used by this workflow. Since the warning is on the `renovate` job, the most targeted fix is to add a `permissions` block under that job. Renovate needs to read repository contents and open/update pull requests; it generally does not need broader repository write access. A reasonable minimal set is `contents: read` and `pull-requests: write`. This keeps `GITHUB_TOKEN` tightly scoped even if Renovate itself authenticates with `secrets.RENOVATE_TOKEN`.

Concretely, in `.github/workflows/renovate.yml`, under `jobs: renovate:`, add a `permissions:` block above `runs-on: ubuntu-latest`. Do not alter the existing steps or environment variables. No imports or external definitions are required, only YAML changes in this workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
